### PR TITLE
Use return instate of exit as the scripts are sourced

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -2,7 +2,7 @@ check_docker_running(){
     if ! docker info > /dev/null 2>&1; then
         echo "ERROR: docker engine isn't running"
         echo "SOLUTION: please start docker and try again!"
-        exit 1
+        return 1
     fi
 }
 
@@ -12,7 +12,7 @@ check_docker_compose_installed(){
     else
         echo "ERROR: Docker-compose is not installed"
         echo "SOLUTION: Please install docker-compose and try again"
-        exit 1
+        return 1
     fi
 }
 
@@ -22,7 +22,7 @@ check_docker_installed(){
     else
         echo "ERROR: Docker is not running"
         echo "ERROR: Please start docker and try again"
-        exit 1
+        return 1
     fi
 }
 
@@ -77,6 +77,6 @@ check_docker_container_running_by_image_used () {
         echo "OK: Docker container running image $image is running"
     else
         echo "ERROR: Docker container running image $image is not running"
-        exit 1
+        return 1
     fi
 }

--- a/scripts/fs.sh
+++ b/scripts/fs.sh
@@ -4,6 +4,6 @@ check_directory() {
     else
         echo "ERROR: Directory $1 does not exist."
         echo "ERROR: Please create the directory $1 try again."
-        exit 1
+        return 1
     fi
 }

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -2,7 +2,7 @@ check_git_installed (){
     if ! git --version > /dev/null 2>&1; then
         echo "ERROR: git is not installed"
         echo "SOLUTION: please install git and try again!"
-        exit 1
+        return 1
     fi
 }
 
@@ -35,13 +35,13 @@ git_checkout_branch() {
         else
             echo "ERROR: Branch $branch does not exist in $folder"
             echo "SOLUTION: Check the branch name and try again"
-            exit 1
+            return 1
         fi
         cd ..
     else
         echo "ERROR: $folder is not a git repository"
         echo "SOLUTION: Please check that the folder includes git historial and try again"
-        exit 1
+        return 1
     fi
 }
 

--- a/scripts/networking.sh
+++ b/scripts/networking.sh
@@ -2,7 +2,7 @@ check_netstat_installed(){
     if ! netstat --version > /dev/null 2>&1; then
         echo "ERROR: netstat is not installed"
         echo "SOLUTION: install the dependency and try again!"
-        exit 1
+        return 1
     fi
 }
 
@@ -11,7 +11,7 @@ check_curl_installed(){
     if ! curl --version > /dev/null 2>&1; then
         echo "ERROR: curl is not installed"
         echo "SOLUTION: install the dependency and try again!"
-        exit 1
+        return 1
     fi
 }
 
@@ -22,7 +22,7 @@ check_http_availability(){
     else
         echo "ERROR: Server is not running on $url"
         echo "SOLUTION: Please check the logs and try again."
-        exit 1
+        return 1
     fi
 }
 
@@ -31,7 +31,7 @@ check_local_mqtt_availability(){
         echo "OK: Mosquitto is running on port 1883"
     else
         echo "ERROR: Mosquitto is not running on port 1883"
-        exit 1
+        return 1
     fi
 }
 
@@ -41,6 +41,6 @@ check_local_websockets_availability(){
         echo "OK: Websocket is running on port $port"
     else
         echo "ERROR: Websocket is not running on port $port"
-        exit 1
+        return 1
     fi
 }

--- a/scripts/secrets.sh
+++ b/scripts/secrets.sh
@@ -8,7 +8,7 @@ load_secrets () {
     else
         echo "ERROR: $file file does not exist."
         echo "SOLUTION: Please create a $file file with the minimum values expected and try again."
-        exit 1
+        return 1
     fi
 }
 
@@ -16,7 +16,7 @@ check_secrets(){
     echo "INFO: Checking for expected environment variables..."
     if [ -z "$MY_SECRET" ]; then
         echo "ERROR: The environment variable MY_SECRET is not set"
-        exit 1
+        return 1
     fi
 
     echo "OK: Expected environment variables are set."


### PR DESCRIPTION
### Main Changes

- Use `return` instead of `exit` as the scripts are sourced (f422ca7)

### Reference

[Bash Reference Manual](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#index-return):

> Cause a shell function to stop executing and return the value `n` to its caller. If `n` is not supplied, the return value is the exit status of the last command executed in the function. If `return` is executed by a trap handler, the last command used to determine the status is the last command executed before the trap handler. If `return` is executed during a DEBUG trap, the last command used to determine the status is the last command executed by the trap handler before return was invoked. `return` may also be used to terminate execution of a script being executed with the . (`source`) builtin, returning either n or the exit status of the last command executed within the script as the exit status of the script. If `n` is supplied, the return value is its least significant 8 bits. Any command associated with the `RETURN` trap is executed before execution resumes after the function or script. The return status is non-zero if `return` is supplied a non-numeric argument or is used outside a function and not during the execution of a script by . or `source`.

### Changelog
- f422ca7 feat: use return instate of exit as the scripts are sourced by @UlisesGascon