### PR TITLE
Add test infrastructure and tests cases for FS scripts

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,4 +19,4 @@ jobs:
       run: make lint
 
     - name: Test
-      run: make test
+      run: make test-ci

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,3 +17,6 @@ jobs:
     
     - name: Lint
       run: make lint
+
+    - name: Test
+      run: make test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Run Hadolint
+      uses: hadolint/hadolint-action@v3.1.0
+      with:
+        dockerfile: Dockerfile.test
     
     - name: Lint
       run: make lint

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM bats/bats:v1.10.0
+
+WORKDIR /home
+
+COPY /scripts ./scripts
+COPY /tests ./tests

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,4 @@
 
 lint:
 	shellcheck scripts/*.sh
+	shellcheck tests/*.bats

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 test:
 	docker build -t bats-tests -f Dockerfile.test .
 	docker run -it --rm bats-tests tests
+test-ci:
+	docker build -t bats-tests -f Dockerfile.test .
+	docker run --rm bats-tests tests
 lint:
 	shellcheck scripts/*.sh
 	shellcheck tests/*.bats

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: test
 
+test:
+	docker build -t bats-tests -f Dockerfile.test .
+	docker run -it --rm bats-tests tests
 lint:
 	shellcheck scripts/*.sh
 	shellcheck tests/*.bats

--- a/tests/fs.bats
+++ b/tests/fs.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load "$(pwd)/scripts/fs.sh"
+
+@test "check_directory with existing directory" {
+    run check_directory "/tmp"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "OK: Directory /tmp exists." ]
+}
+
+@test "check_directory with non-existing directory" {
+    run check_directory "/non/existent/directory"
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "ERROR: Directory /non/existent/directory does not exist." ]
+    [ "${lines[1]}" = "ERROR: Please create the directory /non/existent/directory try again." ]
+}


### PR DESCRIPTION
### Main Changes
- Add test cases for fs file (3ac59bf)
- Extend linter to cover test files (1cd3950)
- Add test command to makefile (013210b)
- Add linter for Docker image (933bc58)
- Add tests step to the pipeline (61e85b4)
- Add a test mode that runs in a non-interactive environment (a5f8485)

### Changelog
- 3ac59bf test: add test cases for fs file by @UlisesGascon
- 1cd3950 chore: extend linter to cover test files by @UlisesGascon
- 013210b feat: add test command to makefile by @UlisesGascon
- 933bc58 feat: add linter for Docker image by @UlisesGascon
- 61e85b4 feat: add tests step to the pipeline by @UlisesGascon
- a5f8485 feat: add a test mode that runs in a non-interactive environment by @UlisesGascon
