### PR TITLE
Rewrite check_secrets function

### DIFF
--- a/scripts/secrets.sh
+++ b/scripts/secrets.sh
@@ -15,7 +15,7 @@ load_secrets () {
     fi
 }
 
-check_secrets() {
+check_environmental_variables() {
     for var in "$@"; do
         if [ -z "${!var}" ]; then
             echo "ERROR: $var is not set."

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -45,16 +45,16 @@ teardown() {
     [[ "${lines[2]}" == "SOLUTION: Please create a notfound file with the minimum values expected and try again." ]]
 }
 
-@test "check_secrets returns success if all environment variables are set" {
-    run check_secrets TEST_SECRET_ONE TEST_SECRET_TWO
+@test "check_environmental_variables returns success if all environment variables are set" {
+    run check_environmental_variables TEST_SECRET_ONE TEST_SECRET_TWO
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "OK: TEST_SECRET_ONE is set." ]]
     [[ "${lines[1]}" == "OK: TEST_SECRET_TWO is set." ]]
 }
 
-@test "check_secrets returns error if an environment variable is not set" {
+@test "check_environmental_variables returns error if an environment variable is not set" {
     unset MY_SECRET
-    run check_secrets TEST_SECRET_ONE INVENTED TEST_SECRET_TWO
+    run check_environmental_variables TEST_SECRET_ONE INVENTED TEST_SECRET_TWO
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" == "OK: TEST_SECRET_ONE is set." ]]
     [[ "${lines[1]}" == "ERROR: INVENTED is not set." ]]


### PR DESCRIPTION
### Main Changes

**Breaking Changes**
- Drop function `check_secrets` (ea7a103)
- Add function `check_environmental_variables` (ea7a103)

**Undestranding `check_environmental_variables`**
This function is used as:

```
check_secrets "DB_USER" "DB_PASS"
```

In this example, check_secrets checks if the `DB_USER` and `DB_PASS` environment variables are set. If either is not set, it prints an error message and returns `1`. If both are set, it prints a confirmation message for each:

```
"OK: DB_USER is set."
"OK: DB_PASS is set."
```

### Changelog
- 668640f feat: rewrite `check_secrets` by @UlisesGascon
- ea7a103 chore: rename `check_secrets` to `check_environmental_variables` by @UlisesGascon
