### PR TITLE
Rewrite git_checkout_branch

### DIFF
--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -47,19 +47,21 @@ git_checkout_branch() {
 
     echo "INFO: Checking out to branch $branch in $folder..."
     if [ -d "$folder/.git" ]; then
-        cd "$folder" || exit 1
-        git fetch && git pull --all
-        if git show-ref --verify --quiet refs/heads/"$branch"; then
-            git checkout "$branch"
-            echo "OK: Branch $branch checked out in $folder"
-        else
-            echo "ERROR: Branch $branch does not exist in $folder"
-            echo "SOLUTION: Check the branch name and try again"
-            exit 1
-        fi
         (
-            cd ..
+            cd "$folder" || exit 1
+            git fetch && git pull --all
+            exists=$(git ls-remote --heads origin "refs/heads/$branch" | wc -l)
+            
+            if [ "$exists" -eq 0 ]; then
+                echo "ERROR: Branch $branch does not exist in $folder"
+                echo "SOLUTION: Check the branch name and try again"
+                exit 1
+            else
+                git checkout "$branch"
+                echo "OK: Branch $branch checked out in $folder"
+            fi
         )
+
     else
         echo "ERROR: $folder is not a git repository"
         echo "SOLUTION: Please check that the folder includes git historial and try again"

--- a/tests/git.bats
+++ b/tests/git.bats
@@ -9,7 +9,7 @@ load "$(pwd)/scripts/git.sh"
 setup() {
     # Mock git command
     git() {
-        if [[ $1 == "--version" || $1 == "clone"  || $1 == "fetch" || $1 == "pull" || $1 == "show-ref" || $1 == "checkout" ]]; then
+        if [[ $1 == "--version" || $1 == "clone"  || $1 == "fetch" || $1 == "pull" || $1 == "checkout" ]]; then
             return 0
         fi
         
@@ -87,9 +87,7 @@ teardown() {
 @test "git_checkout_branch returns error if branch does not exist" {
     # Mock git command
     git() {
-        if [[ $1 == "show-ref" && $2 == "--verify" && $3 == "--quiet" && $4 == refs/heads/* ]]; then
-            return 1
-        else
+        if [[ $1 == "ls-remote" && $2 == "--heads" && $3 == "origin" && $4 == refs/heads/nonexistentbranch ]]; then
             return 0
         fi
     }
@@ -107,10 +105,22 @@ teardown() {
 }
 
 @test "git_checkout_branch checks out to branch if branch and folder are provided" {
+    # Mock git command
+    git() {
+        if [[ $1 == "ls-remote" && $2 == "--heads" && $3 == "origin" && $4 == refs/heads/* ]]; then
+            echo "testbranch"
+        else
+            return 0
+        fi
+    }
+    export -f git
+
     run git_checkout_branch "testbranch" "test"
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "INFO: Checking out to branch testbranch in test..." ]]
     [[ "${lines[1]}" == "OK: Branch testbranch checked out in test" ]]
+
+    unset -f git
 }
 
 @test "git_checkout_branch returns error if folder is not a git repository" {


### PR DESCRIPTION
### Main Changes
- Rewrite `git_checkout_branch` (a28950b)
  - Replaced `git show-ref` for `git ls-remote`
  - Use subshell to avoid change directory in the main script as side effect.

### Changelog
- a28950b feat: rewrite `git_checkout_branch` by @UlisesGascon