### PR TITLE
Rewrite build_docker_simple_image

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -31,22 +31,36 @@ check_docker_installed(){
 build_docker_simple_image(){
     image_name=$1
     dockerfile=$2
-    folder=$3
+    target_directory=$3
+    additional_args=$4
 
     echo "INFO: Building docker image..."
+
+    if [ -z "$image_name" ]; then
+        echo "ERROR: Image name not defined"
+        exit 1
+    fi
 
     if [ -z "$dockerfile" ]; then
         dockerfile="Dockerfile"
         echo "INFO: Dockerfile not defined, using $dockerfile as default"
     fi
 
-    if [ -n "$folder" ]; then
-        cd "$folder" || exit 1
-    fi
+    (
+        if [ -n "$target_directory" ]; then
+            cd "$target_directory" || exit 1
+        fi
 
-    docker build -t "$image_name":latests -f "$dockerfile" .
-    echo "OK: Docker image built."
-}  
+        if [ -n "$additional_args" ]; then
+            # shellcheck disable=SC2086
+            # Spread additional args is a expected behavior
+            docker build -t "$image_name":latest -f "$dockerfile" $additional_args .
+        else
+            docker build -t "$image_name":latest -f "$dockerfile" .
+        fi
+    )
+    echo "OK: Docker image $image_name:latest built."
+}
 
 upsert_docker_compose_file() {
     echo "


### PR DESCRIPTION
### Main Changes

- Rewrite `build_docker_simple_image` (1d225eb)
  - Throw error when `image_name` is not provided
  - Renamed internal variables
  - Added support for additional arguments
  - Added support for subpaths by using subshells

**Usage example**
```

build_docker_simple_image "project"
build_docker_simple_image "project" "Dockerfile-development"
build_docker_simple_image "project" "Dockerfile-development" "project/folder/path"
build_docker_simple_image "project" "Dockerfile" "project/folder/path" "--target final"
```

### Changelog
- 1d225eb feat: rewrite `build_docker_simple_image` by @UlisesGascon

