### PR TITLE
feat: add mode to load_secrets function

### DIFF
--- a/scripts/secrets.sh
+++ b/scripts/secrets.sh
@@ -2,11 +2,27 @@
 
 load_secrets () {
     file=${1:-.env}
-    echo "INFO: Loading secrets from $file file..."
+    mode=${2:-hard}
+    echo "INFO: Loading secrets from $file file in mode: $mode."
     if [ -f "$file" ]; then
         echo "INFO: $file file found"
-        # shellcheck disable=SC1090
-        source "$file"
+        # Load the file directly (hard mode)
+        if [ "$mode" == "hard" ]; then
+            # shellcheck disable=SC1090
+            source "$file"
+        # Load only the variables that are not already set (soft mode)
+        elif [ "$mode" == "soft" ]; then
+            # shellcheck disable=SC1090
+            while IFS='=' read -r var_name var_value; do
+                if [ -z "${!var_name}" ]; then
+                    export "$var_name"="$var_value"
+                fi
+            done < "$file"
+        else
+            echo "ERROR: Invalid mode $mode"
+            echo "SOLUTION: Please use either hard or soft mode"
+            exit 1
+        fi
         echo "OK: secrets loaded from $file file."
     else
         echo "ERROR: $file file does not exist."


### PR DESCRIPTION
### Main Changes

We've added the option to use modes in `load_secrets` (4cfcc86).

**Previous:**
```bash
load_secrets
load_secrets my_file
```

The previous implementation assumed a `hard` mode, meaning that environment variables would be overwritten by the file content in case of collision.

**Current:**
```bash
load_secrets
load_secrets my_file
load_secrets my_file hard
load_secrets my_file soft
```

Now, with this version, it's possible to use the `soft` mode as well. In soft mode, existing variables will not be overwritten when loading new ones if they don't exist previously.

Note: This change doesn't break retrocompatibility, so no migration is required. We assume that you still use the `hard` mode by default.

Note: This does not break the retrocompatibility, so no migration is required. We assume that you use the hard mode by default.

### Changelog

- 4cfcc86 feat: add mode to load_secrets function by @UlisesGascon
